### PR TITLE
Add stylesheets to generator

### DIFF
--- a/lib/generators/spree_rdr_theme/install/install_generator.rb
+++ b/lib/generators/spree_rdr_theme/install/install_generator.rb
@@ -7,6 +7,10 @@ module SpreeRdrTheme
         append_file "app/assets/javascripts/store/all.js", "//= require store/rdr_wishlist\n" 
       end
       
+      def add_stylesheets
+        inject_into_file "app/assets/stylesheets/store/all.css", " *= require store/rdr\n", :before => /\*\//, :verbose => true
+      end
+      
     end
   end
 end


### PR DESCRIPTION
This is a fix for Issue #8. Theme css was not getting loaded. This adds css to install generator so that css gets loaded into store/all.css.
