### PR TITLE
removed dubplicate items from showing up on taxon route

### DIFF
--- a/app/overrides/spree/taxons/replace_taxon_children.rb
+++ b/app/overrides/spree/taxons/replace_taxon_children.rb
@@ -1,6 +1,3 @@
 Deface::Override.new(:virtual_path => %q{spree/taxons/show},
                      :name => %q{replace_taxon_children},
-                     :replace => %q{[data-hook='taxon_children']},
-                     :text => %q{<div data-hook="taxon_products">
-    <%= render :partial => "spree/shared/products", :locals => {:products => @products, :taxon => @taxon } %>
-  </div>})
+                     :remove => %q{[data-hook='taxon_children']})


### PR DESCRIPTION
For this route, localhost:3000/t/categories/clothing, items where listed 2x.

Please see exmaple spree app for visual confirmation of changes. https://github.com/westonplatter/test_spree-1.2/tree/65db9a666dd8e93c4bda60bdf9a251b804bf8716
