### PR TITLE
fixed /cart path - use @order.item_total

### DIFF
--- a/app/overrides/spree/orders/replace_cart_detail.rb
+++ b/app/overrides/spree/orders/replace_cart_detail.rb
@@ -27,7 +27,7 @@ Deface::Override.new(:virtual_path => %q{spree/orders/_form},
     <tr class="totals">
       <td colspan="6">&nbsp;</td>
       <td colspan="2" class="totals">
-        <%= t(:subtotal) %>: <span class="order-total"><%= order_subtotal(@order) %></span>
+        <%= t(:subtotal) %>: <span class="order-total"><%= @order.item_total %></span>
       </td>
     </tr>
   </tbody>


### PR DESCRIPTION
followed Spree 1.2.2 convetions, https://github.com/spree/spree/blob/a4c4079f6d0b9d516413b192a50cc8a6b07e5010/core/app/views/spree/shared/_order_details.html.erb#L109
